### PR TITLE
upgrade haproxy from 2.4 to v2.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM haproxy:2.4
+FROM haproxy:2.6
 
 LABEL maintainer="tjveil@gmail.com"
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -59,8 +59,6 @@ function buildConfig() {
 global
     log stdout format raw local0 info
     maxconn 4096
-    nbproc 1
-    nbthread 4
 
 defaults
     log                 global


### PR DESCRIPTION
The `nbproc` option is deprecated & removed since v2.5
_http://docs.haproxy.org/2.4/configuration.html#3.1-nbproc_

The `nbthread` option is not used (no `thread` config on bind lines), so, let HA defaults apply 
_https://www.haproxy.com/blog/announcing-haproxy-2-5/#better-control-over-threads_